### PR TITLE
Fix: support Infolists\Components\Actions

### DIFF
--- a/src/Infolists/Components/TableRepeatableEntry.php
+++ b/src/Infolists/Components/TableRepeatableEntry.php
@@ -27,9 +27,9 @@ class TableRepeatableEntry extends RepeatableEntry
 
         foreach ($components as $component) {
             $this->columnLabels[] = [
-                'component' => $component->getName(),
+                'component' =>  method_exists($component, 'getName') ? $component->getName(): null,
                 'name' => $component->getLabel(),
-                'alignment' => $component->getAlignment()
+                'alignment' => method_exists($component, 'getAlignment') ? $component->getAlignment(): null
             ];
         }
     }


### PR DESCRIPTION

This pull request includes a modification to the `setColumnLabels` method in the `TableRepeatableEntry` component to handle cases where certain methods may not exist on the components being processed.

Error handling improvements:

* [`src/Infolists/Components/TableRepeatableEntry.php`](diffhunk://#diff-7d49964c286d748b080329b384f64ae77a9cc35f86b89305d93231cd774fa646L30-R32): Modified the `setColumnLabels` method to check if `getName` and `getAlignment` methods exist on the component before calling them, ensuring that `null` is assigned if the methods do not exist.

There aren't any methods `getName` and `getAlignment` for `Infolists\Components\Actions`.
By having this fix you can add Actions to the table.

```
\Icetalker\FilamentTableRepeatableEntry\Infolists\Components\TableRepeatableEntry::make('table')
->schema([
\Filament\Infolists\Components\Actions::make([
        Action::make('star')
        ->icon('heroicon-m-star')
        ->requiresConfirmation()
        ->action(function (Star $star) {
            $star();
        }),
]);
```

![image](https://github.com/user-attachments/assets/6cb57165-d961-41f3-8b24-f7da74afba58)

